### PR TITLE
Fixed bug with incorrect version number

### DIFF
--- a/MapleStream.cs
+++ b/MapleStream.cs
@@ -53,7 +53,7 @@ namespace MapleShark
                 pLocale == MapleLocale.CHINA || 
                 pLocale == MapleLocale.CHINA_TEST ||
                 pLocale == MapleLocale.JAPAN || 
-                (pLocale == MapleLocale.GLOBAL && pBuild >= 149) || 
+                (pLocale == MapleLocale.GLOBAL && (short)pBuild >= 149) || 
                 (pLocale == MapleLocale.KOREA && pBuild >= 221) ||
                 (pLocale == MapleLocale.SOUTH_EAST_ASIA && pBuild >= 144))
             {

--- a/SessionForm.cs
+++ b/SessionForm.cs
@@ -166,7 +166,8 @@ namespace MapleShark
                 }
                 else if (patchLocation.All(character => { return character >= '0' && character <= '9'; }))
                 {
-                    subVersion = byte.Parse(patchLocation);
+		    if (!byte.TryParse(patchLocation, out subVersion))
+		        Console.WriteLine("Failed to parse subVersion");
                 }
 
                 mBuild = version;


### PR DESCRIPTION
pBuild is cast to signed short to prevent a negative build from being
greater than 149.
subVersion no longer automaticly assumes patchLocation is a valid byte
to parse.